### PR TITLE
Update FluentFMRepository.php

### DIFF
--- a/src/Connection/FluentFMRepository.php
+++ b/src/Connection/FluentFMRepository.php
@@ -371,9 +371,9 @@ class FluentFMRepository extends BaseConnection implements FluentFM
             } else {
                 throw $e;
             }
+        } finally {
+            $this->clearQuery();
         }
-
-        $this->clearQuery();
 
         return $results;
     }


### PR DESCRIPTION
If  you throw an exception without clearing query it causes a problem if previous request is failed because old query params appears in new request